### PR TITLE
fix next, stepIn and stepOut were not responded before stopped

### DIFF
--- a/debuggee/test.lua
+++ b/debuggee/test.lua
@@ -1,0 +1,25 @@
+-- 유티에프-팔
+require 'strict'
+package.path = '?.lua;lua/?.lua;' .. package.path
+local json = require 'dkjson'
+
+local function onError(e)
+	print('[onError]' .. e)
+end
+
+local debuggee = (require 'vscode-debuggee')
+local startResult, breakerType = debuggee.start(json, { onError = onError })
+print('debuggee.start(): ', tostring(startResult), breakerType)
+
+local function b()
+	print('in function b')
+end
+
+local function a(t, ...)
+	print('in function a ' .. t.k)
+	b()
+	print('in function a end')
+end
+
+a({k = 10}, 20, 30)
+print('in test')

--- a/debuggee/vscode-debuggee.lua
+++ b/debuggee/vscode-debuggee.lua
@@ -312,7 +312,7 @@ local function sendFully(str)
 	local first = 1
 	while first <= #str do
 		local sent = sock:send(str, first)
-		if sent > 0 then
+		if sent and sent > 0 then
 			first = first + sent;
 		else
 			error('sock:send() returned < 0')
@@ -677,10 +677,20 @@ function handlers.scopes(req)
 end
 
 -------------------------------------------------------------------------------
-local function registerVar(name, value, noQuote)
+local function registerVar(name_, value, noQuote, index)
 	local ty = type(value)
+	local name
+	if type(name_) == 'number' then
+		name = '[' .. name_ .. ']'
+	else
+		name = tostring(name_)
+	end
+	if index then
+		name = name .. ' /' .. index
+	end
+	
 	local item = {
-		name = (type(name) == 'number') and name or tostring(name),
+		name = name,
 		type = ty
 	}
 
@@ -706,8 +716,8 @@ end
 function handlers.variables(req)
 	local varRef = req.arguments.variablesReference
 	local variables = {}
-	local function addVar(name, value, noQuote)
-		variables[#variables + 1] = registerVar(name, value, noQuote) 
+	local function addVar(name, value, noQuote, index)
+		variables[#variables + 1] = registerVar(name, value, noQuote, index) 
 	end
 
 	if (varRef >= 1000000) then
@@ -718,7 +728,7 @@ function handlers.variables(req)
 			for i = 1, 9999 do
 				local name, value = debug.getlocal(depth, i)
 				if name == nil then break end
-				addVar(name, value)
+				addVar(name, value, nil, i)
 			end
 		elseif scopeType == scopeTypes.Upvalues then
 			local info = debug.getinfo(depth, 'f')
@@ -726,7 +736,7 @@ function handlers.variables(req)
 				for i = 1, 9999 do
 					local name, value = debug.getupvalue(info.func, i)
 					if name == nil then break end
-					addVar(name, value)
+					addVar(name, value, nil, i)
 				end
 			end
 		elseif scopeType == scopeTypes.Globals then

--- a/debuggee/vscode-debuggee.lua
+++ b/debuggee/vscode-debuggee.lua
@@ -795,6 +795,7 @@ end
 function handlers.next(req)
 	stepTargetHeight = stackHeight() - breaker.stackOffset.step
 	breaker.setLineBreak(step)
+	sendSuccess(req, {})
 	return 'CONTINUE'
 end
 
@@ -802,6 +803,7 @@ end
 function handlers.stepIn(req)
 	stepTargetHeight = nil
 	breaker.setLineBreak(step)
+	sendSuccess(req, {})
 	return 'CONTINUE'
 end
 
@@ -809,6 +811,7 @@ end
 function handlers.stepOut(req)
 	stepTargetHeight = stackHeight() - (breaker.stackOffset.step + 1)
 	breaker.setLineBreak(step)
+	sendSuccess(req, {})
 	return 'CONTINUE'
 end
 


### PR DESCRIPTION
vscode version, 1.9.1
plugin, devCAT.lua-debug-1.0.8
debugee, [master](https://github.com/devcat-studio/VSCodeLuaDebug/blob/master/debuggee/vscode-debuggee.lua)

according to [debugProtocol.d.ts](https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/parts/debug/common/debugProtocol.d.ts)
> 	/** Next request; value of command field is 'next'.
		The request starts the debuggee to run again for one step.
		The debug adapter first sends the NextResponse and then a StoppedEvent (event type 'step') after the step has completed.
	*/

In my tests, step didn't work without responding to those requests. 