### PR TITLE
Debugee waiting 중에 창을 꺼도 VSCode 가 이상한 상태에 빠지지 않음

### DIFF
--- a/DebugAdapter/Main.cs
+++ b/DebugAdapter/Main.cs
@@ -25,6 +25,15 @@ namespace VSCodeDebug
             Application.Run(WaitingUI);
         }
 
+        private static ICDPSender toVSCode;
+
+        public static void Stop()
+        {
+            if (toVSCode != null) {
+                toVSCode.SendMessage(new TerminatedEvent());
+            }
+        }
+
         public static void DebugSessionLoop()
         {
             try
@@ -35,6 +44,7 @@ namespace VSCodeDebug
                 var cdp = new VSCodeDebugProtocol(debugSession);
 
                 debugSession.toVSCode = cdp;
+                toVSCode = cdp;
 
                 cdp.Loop(Console.OpenStandardInput(), Console.OpenStandardOutput());
             }

--- a/DebugAdapter/WaitingUI.cs
+++ b/DebugAdapter/WaitingUI.cs
@@ -18,6 +18,7 @@ namespace VSCodeDebug
 
         private void WaitingUI_FormClosing(object sender, FormClosingEventArgs e)
         {
+            Program.Stop();
             Environment.Exit(0);
         }
 


### PR DESCRIPTION
Debugee가 연결되지 않은 채 WaitingUI가 꺼지면
```
Error: "Debug adapter process has terminated unexpectedly"
Error: "Cannot read property 'toLowerCase' of undefined"
```
같은 에러 노티가 뜨고 이상한 상태에 빠져 VSCode를 재시작하기 전까지 DebugAdapter가 실행되지 않던 문제를 수정했습니다.